### PR TITLE
AE-178 Fix pagination

### DIFF
--- a/src/components/Form/Select/Select.tsx
+++ b/src/components/Form/Select/Select.tsx
@@ -44,7 +44,7 @@ export interface Props extends ComponentPropsWithRef<"select">, FormElement {
   describedBy?: string;
   placeholder?: string;
   searchPlaceholder?: string;
-  searchInputProps?: PartialInputProps;
+  searchInputProps?: PartialInputProps & { reset?: boolean };
   selectButtonProps?: ComponentPropsWithRef<"button">;
   className?: string;
   value: string;
@@ -90,7 +90,6 @@ const SelectComponent: ForwardRefRenderFunction<HTMLSelectElement, Props> = (
       false
     ); /** We need this, because whenever we use the arrow keys to select the select item, and we focus the currently selected item it fires the "click" listener in Option component. Instead, we only want this to fire if we press "enter" or "spacebar" so we set this to true whenever that is the case, and back to false when it has been executed. */
   const [shouldFocusButtonAfterClose, setShouldFocusButtonAfterClose] = useState(false);
-  const [childrenCount] = useState(React.Children.count(children));
 
   const nativeSelect = (ref as React.RefObject<HTMLSelectElement>) || createRef();
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -112,7 +111,7 @@ const SelectComponent: ForwardRefRenderFunction<HTMLSelectElement, Props> = (
     setIsSearching,
     setFocusedSelectItem,
     onOptionChangeHandler,
-    childrenCount,
+    childrenCount: React.Children.count(children),
     setShouldClick,
     searchInputRef,
     renderSearchCondition
@@ -238,6 +237,16 @@ const SelectComponent: ForwardRefRenderFunction<HTMLSelectElement, Props> = (
     },
     expanded
   );
+
+  const resetSearchState = () => {
+    setFilter("");
+    setIsSearching(false);
+    setFocusedSelectItem(-1);
+  };
+
+  useEffect(() => {
+    searchInputProps?.reset && resetSearchState();
+  }, [searchInputProps?.reset]);
 
   const additionalClasses = [];
   expanded && additionalClasses.push(classes.expanded);

--- a/src/components/Pagination/Pagination.module.scss
+++ b/src/components/Pagination/Pagination.module.scss
@@ -34,6 +34,10 @@
   .form-element {
     height: 2.5rem;
 
+    .search-input-wrapper {
+      width: 2.75rem;
+    }
+
     button {
       min-height: 2.5rem;
     }

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -16,7 +16,7 @@
 
 import React, { useEffect, useRef } from "react";
 import { Pagination, Props } from "./Pagination";
-import { act, render, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const defaultParams: Props = {
@@ -60,8 +60,8 @@ describe("Pagination events", () => {
     const { pagination } = createPagination(defaultParams => ({
       ...defaultParams,
       currentPage: 10,
-      onPageChange: onPageChange,
-      onPageSizeChange: onPageSizeChange
+      onPageChange,
+      onPageSizeChange
     }));
 
     const next = pagination.querySelector('[data-paginate="next"]')!;
@@ -79,7 +79,7 @@ describe("Pagination events", () => {
     await waitFor(() => expect(onPageChange).toHaveBeenCalledWith(9));
 
     await userEvent.click(first);
-    await waitFor(() => expect(onPageChange).toHaveBeenCalledWith(0));
+    await waitFor(() => expect(onPageChange).toHaveBeenCalledWith(1));
 
     await userEvent.click(last);
     await waitFor(() => expect(onPageChange).toHaveBeenCalledWith(50));
@@ -102,28 +102,28 @@ describe("different current pages and their effect on what renders", () => {
     expect(pagination.querySelector('[data-paginate="previous"]')).toHaveAttribute("disabled");
   });
 
-  it("is on the second page and does not render first", async () => {
+  it("is on the second page and does render first", async () => {
     const { pagination } = createPagination(defaultParams => ({
       ...defaultParams,
       currentPage: 2
     }));
 
-    expect(pagination.querySelector('[data-paginate="first"]')).toHaveAttribute("disabled");
+    expect(pagination.querySelector('[data-paginate="first"]')).not.toHaveAttribute("disabled");
   });
 
-  it("is on the second to last page and does not render last", () => {
+  it("is on the second to last page and does render last", () => {
     const { pagination } = createPagination(defaultParams => ({
       ...defaultParams,
-      currentPage: 499
+      currentPage: 49
     }));
 
-    expect(pagination.querySelector('[data-paginate="last"]')).toHaveAttribute("disabled");
+    expect(pagination.querySelector('[data-paginate="last"]')).not.toHaveAttribute("disabled");
   });
 
   it("is on the last page and does not render next & last", () => {
     const { pagination } = createPagination(defaultParams => ({
       ...defaultParams,
-      currentPage: 500
+      currentPage: 50
     }));
 
     expect(pagination.querySelector('[data-paginate="last"]')).toHaveAttribute("disabled");

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -18,7 +18,6 @@ import React, {
   ForwardRefRenderFunction,
   ComponentPropsWithRef,
   Fragment,
-  useRef,
   useState,
   useEffect
 } from "react";

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -147,7 +147,8 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
                 className={`${classes["form-element"]} ${classes["current-page-select"]}`}
                 searchInputProps={{
                   wrapperProps: { className: classes["search-input-wrapper"] },
-                  reset: resetPageNoSelect
+                  reset: resetPageNoSelect,
+                  autoComplete: "off"
                 }}
               >
                 {Array.from(Array(pagesAmount).keys()).map(page => (

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -74,6 +74,7 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
 
     return Math.ceil(totalElements / pageSize);
   };
+  const pagesAmount = calculateAmountOfPages();
 
   const onPageSizeChangeHandler = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const pageSizeNumber = Number(event.target.value) as PageSize;
@@ -112,7 +113,7 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
       </div>
       <div className={classes["pagination"]}>
         <Fragment>
-          {totalElements && !!calculateAmountOfPages() && (
+          {totalElements && !!pagesAmount && (
             <div className={classes["page"]}>
               <Label
                 id="current-value-input-label"
@@ -125,15 +126,16 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
                 aria-labelledby="current-value-input-label"
                 key="input"
                 id="current-value-input"
-                size={currentPage?.toString().length}
+                size={currentPage.toString().length}
                 onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
                   onPageChangeHandler(Number(e.target.value))
                 }
                 name="current-value-input"
                 value={currentPage.toString()}
                 className={`${classes["form-element"]} ${classes["current-page-select"]}`}
+                searchInputProps={{ wrapperProps: { className: classes["search-input-wrapper"] } }}
               >
-                {Array.from(Array(calculateAmountOfPages()!).keys()).map(page => (
+                {Array.from(Array(pagesAmount!).keys()).map(page => (
                   <Option key={page} value={(page + 1).toString()}>
                     {(page + 1).toString()}
                   </Option>
@@ -151,9 +153,9 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
             <div className={classes["previous"]}>
               {
                 <IconButton
-                  disabled={currentPage <= 2}
+                  disabled={currentPage <= 1}
                   title="first"
-                  onClick={() => onPageChangeHandler(0)}
+                  onClick={() => onPageChangeHandler(1)}
                   data-paginate="first"
                 >
                   <Icon icon={Icons.NavigationFirst} />
@@ -174,7 +176,7 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
           <div className={classes["next"]}>
             {!!(currentPage !== undefined || (currentPage !== undefined && !totalElements)) && (
               <IconButton
-                disabled={currentPage >= calculateAmountOfPages()!}
+                disabled={currentPage >= pagesAmount}
                 title="next"
                 onClick={() => onPageChangeHandler(currentPage + 1)}
                 data-paginate="next"
@@ -184,7 +186,7 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
             )}
             {!!(currentPage && totalElements) && (
               <IconButton
-                disabled={currentPage >= calculateAmountOfPages()! - 1}
+                disabled={currentPage >= pagesAmount}
                 title="last"
                 onClick={() => onPageChangeHandler(Math.ceil(totalElements / pageSize))}
                 data-paginate="last"

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -14,7 +14,14 @@
  *    limitations under the License.
  */
 
-import React, { ForwardRefRenderFunction, ComponentPropsWithRef, Fragment } from "react";
+import React, {
+  ForwardRefRenderFunction,
+  ComponentPropsWithRef,
+  Fragment,
+  useRef,
+  useState,
+  useEffect
+} from "react";
 import classes from "./Pagination.module.scss";
 import readyclasses from "../../readyclasses.module.scss";
 import { IconButton } from "../Button/IconButton";
@@ -75,15 +82,21 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
     return Math.ceil(totalElements / pageSize);
   };
   const pagesAmount = calculateAmountOfPages();
+  const [resetPageNoSelect, setResetPageNoSelect] = useState(false);
 
   const onPageSizeChangeHandler = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const pageSizeNumber = Number(event.target.value) as PageSize;
+    setResetPageNoSelect(true);
     onPageSizeChange(pageSizeNumber);
   };
 
   const onPageChangeHandler = (pageToGoTo: number) => {
     onPageChange(pageToGoTo);
   };
+
+  useEffect(() => {
+    resetPageNoSelect && setResetPageNoSelect(false);
+  }, [resetPageNoSelect]);
 
   return (
     <div {...rest} ref={ref} className={`${classes["pagination-wrapper"]} ${className ?? ""}`}>
@@ -123,7 +136,7 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
                 {translate.currentPageLabel}
               </Label>
               <Select
-                aria-labelledby="current-value-input-label"
+                labeledBy="current-value-input-label"
                 key="input"
                 id="current-value-input"
                 size={currentPage.toString().length}
@@ -133,9 +146,12 @@ const PaginationComponent: ForwardRefRenderFunction<HTMLDivElement, Props> = (
                 name="current-value-input"
                 value={currentPage.toString()}
                 className={`${classes["form-element"]} ${classes["current-page-select"]}`}
-                searchInputProps={{ wrapperProps: { className: classes["search-input-wrapper"] } }}
+                searchInputProps={{
+                  wrapperProps: { className: classes["search-input-wrapper"] },
+                  reset: resetPageNoSelect
+                }}
               >
-                {Array.from(Array(pagesAmount!).keys()).map(page => (
+                {Array.from(Array(pagesAmount).keys()).map(page => (
                   <Option key={page} value={(page + 1).toString()}>
                     {(page + 1).toString()}
                   </Option>

--- a/stories/DataGrid/DataGrid.stories.tsx
+++ b/stories/DataGrid/DataGrid.stories.tsx
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { Meta } from "@storybook/react";
 import { DataGrid as DataGridComponent, Props } from "../../src/components/DataGrid/DataGrid";
 import { DataGridRow } from "../../src/components/DataGrid/DataGridBody/DataGridRow";
@@ -27,6 +27,7 @@ import DataGridDocumentation from "./DataGrid.mdx";
 import { action } from "@storybook/addon-actions";
 import { within, userEvent, waitFor } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
+import { PageSize } from "../../src/components/Pagination/Pagination";
 
 export default {
   title: "components/Data Display/DataGrid",
@@ -51,11 +52,25 @@ const Template = args => {
       </DataGridRow>
     );
   };
+  const [pageSize, setPageSize] = useState(10);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const data = args.data;
+  const paginationProps = args.paginationProps;
+  paginationProps.pageSize = pageSize;
+  paginationProps.currentPage = currentPage;
+  paginationProps.onPageSizeChange = (pageSize: PageSize) => {
+    setPageSize(pageSize);
+    setCurrentPage(1);
+  };
+  paginationProps.onPageChange = (pageNo: number) => {
+    setCurrentPage(pageNo);
+  };
 
   return (
     <div style={{ padding: "1rem", backgroundColor: "rgb(245, 248, 248)" }}>
       <div style={{ borderRadius: ".5rem", backgroundColor: "#FFF" }}>
-        <DataGridComponent {...args}>
+        <DataGridComponent {...args} data={data} paginationProps={paginationProps}>
           {({
             item
           }: {
@@ -110,7 +125,16 @@ DefaultDataGrid.args = {
       id: "2",
       type: "Stock",
       enabled: false
-    }
+    },
+    ...Array(100)
+      .fill(0)
+      .map((_value, index) => ({
+        name: "Company gen" + index,
+        created: new Date(2023, 0, 2),
+        id: "gen" + index,
+        type: "Stock",
+        enabled: false
+      }))
   ],
   headers: [
     { name: "name", headline: "Name" },
@@ -133,7 +157,7 @@ DefaultDataGrid.args = {
   },
   disableContextMenuColumn: false,
   paginationProps: {
-    totalElements: 2,
+    totalElements: 102,
     currentPage: 1
   },
   isLoading: false,

--- a/stories/DataGrid/DataGrid.stories.tsx
+++ b/stories/DataGrid/DataGrid.stories.tsx
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import { Meta } from "@storybook/react";
 import { DataGrid as DataGridComponent, Props } from "../../src/components/DataGrid/DataGrid";
 import { DataGridRow } from "../../src/components/DataGrid/DataGridBody/DataGridRow";
@@ -27,7 +27,6 @@ import DataGridDocumentation from "./DataGrid.mdx";
 import { action } from "@storybook/addon-actions";
 import { within, userEvent, waitFor } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
-import { PageSize } from "../../src/components/Pagination/Pagination";
 
 export default {
   title: "components/Data Display/DataGrid",
@@ -40,37 +39,10 @@ export default {
 } as Meta;
 
 const Template = args => {
-  const row = ({ item }) => {
-    if (!item) return;
-    return (
-      <DataGridRow key={item.id}>
-        <DataGridCell>{item.name}</DataGridCell>
-        <DataGridCell>{item.created.toLocaleDateString()}</DataGridCell>
-        <DataGridCell>{item.id}</DataGridCell>
-        <DataGridCell>{item.type}</DataGridCell>
-        <DataGridCell>{item.enabled ? "Active" : "Delisted"}</DataGridCell>
-      </DataGridRow>
-    );
-  };
-  const [pageSize, setPageSize] = useState(10);
-  const [currentPage, setCurrentPage] = useState(1);
-
-  const data = args.data;
-  const paginationProps = args.paginationProps;
-  paginationProps.pageSize = pageSize;
-  paginationProps.currentPage = currentPage;
-  paginationProps.onPageSizeChange = (pageSize: PageSize) => {
-    setPageSize(pageSize);
-    setCurrentPage(1);
-  };
-  paginationProps.onPageChange = (pageNo: number) => {
-    setCurrentPage(pageNo);
-  };
-
   return (
     <div style={{ padding: "1rem", backgroundColor: "rgb(245, 248, 248)" }}>
       <div style={{ borderRadius: ".5rem", backgroundColor: "#FFF" }}>
-        <DataGridComponent {...args} data={data} paginationProps={paginationProps}>
+        <DataGridComponent {...args}>
           {({
             item
           }: {
@@ -125,16 +97,7 @@ DefaultDataGrid.args = {
       id: "2",
       type: "Stock",
       enabled: false
-    },
-    ...Array(100)
-      .fill(0)
-      .map((_value, index) => ({
-        name: "Company gen" + index,
-        created: new Date(2023, 0, 2),
-        id: "gen" + index,
-        type: "Stock",
-        enabled: false
-      }))
+    }
   ],
   headers: [
     { name: "name", headline: "Name" },
@@ -157,7 +120,7 @@ DefaultDataGrid.args = {
   },
   disableContextMenuColumn: false,
   paginationProps: {
-    totalElements: 102,
+    totalElements: 2,
     currentPage: 1
   },
   isLoading: false,

--- a/stories/Pagination/Pagination.mdx
+++ b/stories/Pagination/Pagination.mdx
@@ -8,36 +8,45 @@ The pagination component makes the content readable by separating it into differ
 
 It has a few strings of text that can be translated. These are accessible through the `translate` prop; English is the default language. Please see the props table for the object interface. The `itemsPerPageLabel` and `currentPageLabel` are specifically for accessibility. Whenever the user tabs onto the `Select` component for `itemsPerPage` or the `Input` component for the `currentPage`, their respective labels will be read by the screen reader.
 
+## Using `onPageChange` and `onPageSizeChange` callbacks
+
+The Pagination component provides two important callbacks:
+
+- The `onPageChange` callback notifies you when the user changes the selected page. It receives one parameter, `pageNo`.
+  The page numbering starts at 1 to match typical human-friendly conventions.
+- The `onPageSizeChange` callback handles changes in items per page. It triggers when the user selects a new page size.
+  To ensure proper display of items for the new page size, developers should also update the `currentPage` property of the Pagination component.
+
 # Examples
 
 An example component that's using the `Pagination` component is shown below:
 
 ```jsx
 const ExampleComponent = () => {
-  const [currentPage, setCurrentPage] = useState(0);
-  const [totalElements, setTotalElements] = useState(100);
-  const [pageSize, setPageSize] = useState(10)
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
 
-  const onPageChange = (action: 'first' | 'previous' | 'next', 'last') => {
-    switch(action) {
-      case 'first':
-        setCurrentPage(0);
-      case 'previous':
-        setCurrentPage(currPage => currPage - 1);
-      case: 'next':
-        setCurrentPage(currPage => currPage + 1);
-      case: 'last':
-        setCurrentPage(totalElements / pageSize);
-    }
-  }
+  const onPageSizeChange = (pageSize: PageSize) => {
+    setPageSize(pageSize);
+    setCurrentPage(1);
+  };
+  const onPageChange = (pageNo: number) => {
+    setCurrentPage(pageNo);
+  };
 
   <Pagination
     currentPage={currentPage}
     totalElements={totalElements}
     pageSize={pageSize}
-    onCurrentPageChange={(pageNumber: number) => setCurrentPage(pageNumber)}
-    onPageChange={(pageChangeAction: 'first' | 'previous' | 'next', 'last') => onPageChange(pageChangeAction)}
-    onPageSizeChange={(pageSize: 10 | 25 | 50) => setPageSize(pageSize)}
+    onPageChange={onPageChange}
+    onPageSizeChange={onPageSizeChange}
+    translate={{
+      totalItems: "items in total",
+      itemsPerPage: "Items per page",
+      itemsPerPageLabel: "Select how many items per page you want to see.",
+      currentPage: "of %1 pages",
+      currentPageLabel: "What page you are currently on."
+    }}
      />
 }
 ```

--- a/stories/Pagination/Pagination.stories.tsx
+++ b/stories/Pagination/Pagination.stories.tsx
@@ -14,13 +14,16 @@
  *    limitations under the License.
  */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Meta, Story } from "@storybook/react";
 import {
+  PageSize,
   Pagination as PaginationComponent,
   Props
 } from "../../src/components/Pagination/Pagination";
 import PaginationDocumentation from "./Pagination.mdx";
+import { within, userEvent, waitFor, getByRole } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
 
 const meta: Meta = {
   title: "components/Navigation/Pagination",
@@ -47,18 +50,189 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story<Props> = args => (
-  <div style={{ margin: "0 auto" }}>
-    <PaginationComponent {...args} />
-  </div>
-);
+const Template: Story<Props> = args => {
+  const [currentPage, setCurrentPage] = useState(args.currentPage);
+  const [pageSize, setPageSize] = useState(args.pageSize);
+
+  const onPageSizeChange = (pageSize: PageSize) => {
+    setPageSize(pageSize);
+    setCurrentPage(1);
+  };
+  const onPageChange = (pageNo: number) => {
+    setCurrentPage(pageNo);
+  };
+
+  useEffect(() => {
+    if (args.currentPage !== currentPage) {
+      setCurrentPage(args.currentPage);
+    }
+    if (args.pageSize !== pageSize) {
+      setPageSize(args.pageSize);
+    }
+  }, [args.pageSize, args.currentPage]);
+
+  return (
+    <div style={{ margin: "0 auto" }}>
+      <PaginationComponent
+        {...args}
+        currentPage={currentPage}
+        pageSize={pageSize}
+        onPageSizeChange={onPageSizeChange}
+        onPageChange={onPageChange}
+      />
+    </div>
+  );
+};
 
 export const Pagination = Template.bind({});
 
+Pagination.play = async ({ canvasElement, args, step }) => {
+  const canvas = within(canvasElement);
+
+  const waitForStoryToBeReady = async () => {
+    await waitFor(() =>
+      expect(canvas.queryByText(args.translate.itemsPerPage)).toBeInTheDocument()
+    );
+  };
+
+  await step("Select items per page changes number of pages", async () => {
+    await waitForStoryToBeReady();
+    const pageSizeButton = canvas.getByRole("button", {
+      expanded: false,
+      name: args.translate!.itemsPerPage
+    });
+
+    await waitFor(() => expect(pageSizeButton).toHaveTextContent("10"));
+    expect(canvas.queryByText(args.translate.currentPage.replace("%1", "25"))).toBeInTheDocument();
+
+    await userEvent.click(pageSizeButton);
+
+    const itemPerPage25 = canvas.getByRole("option", { name: "25" });
+    await userEvent.click(itemPerPage25);
+    expect(pageSizeButton).toHaveTextContent("25");
+    expect(canvas.queryByText(args.translate.currentPage.replace("%1", "10"))).toBeInTheDocument();
+  });
+
+  await step("Select pages", async () => {
+    const pageSizeButton = canvas.getByRole("button", {
+      expanded: false,
+      name: args.translate!.itemsPerPage
+    });
+    const pageNoButton = canvas.getByRole("button", {
+      expanded: false,
+      name: args.translate!.currentPageLabel
+    });
+    const firstPageButton = canvas.getByRole("button", {
+      hidden: true,
+      name: "first"
+    });
+    const prevPageButton = canvas.getByRole("button", {
+      hidden: true,
+      name: "previous"
+    });
+    const nextPageButton = canvas.getByRole("button", {
+      hidden: true,
+      name: "next"
+    });
+    const lastPageButton = canvas.getByRole("button", {
+      hidden: true,
+      name: "last"
+    });
+
+    const expectPageNavigationButtonAvailability = (
+      forPage: "firstPage" | "oneOfMiddlePages" | "lastPage"
+    ) => {
+      if (forPage === "firstPage") {
+        expect(firstPageButton).toBeDisabled();
+        expect(prevPageButton).toBeDisabled();
+        expect(nextPageButton).not.toBeDisabled();
+        expect(lastPageButton).not.toBeDisabled();
+      } else if (forPage === "lastPage") {
+        expect(firstPageButton).not.toBeDisabled();
+        expect(prevPageButton).not.toBeDisabled();
+        expect(nextPageButton).toBeDisabled();
+        expect(lastPageButton).toBeDisabled();
+      } else {
+        expect(firstPageButton).not.toBeDisabled();
+        expect(prevPageButton).not.toBeDisabled();
+        expect(nextPageButton).not.toBeDisabled();
+        expect(lastPageButton).not.toBeDisabled();
+      }
+    };
+
+    const selectItemsPerPage = async (size: "10" | "25" | "50") => {
+      await userEvent.click(pageSizeButton);
+      const selectedSize = canvas.getByRole("option", { name: size });
+      await userEvent.click(selectedSize);
+      await waitFor(() => expect(pageSizeButton).toHaveTextContent(size));
+    };
+
+    await step("Select first page by changing page size", async () => {
+      await waitForStoryToBeReady();
+
+      await selectItemsPerPage("10");
+      expectPageNavigationButtonAvailability("firstPage");
+    });
+
+    await step(
+      "Select first page by changing page size and then select last page using select component",
+      async () => {
+        await waitForStoryToBeReady();
+        await selectItemsPerPage("50");
+        await waitFor(() => expect(pageNoButton).toHaveTextContent("1"));
+        expectPageNavigationButtonAvailability("firstPage");
+        await userEvent.click(pageNoButton);
+        const pageNo5 = canvas.getByRole("option", { name: "5" });
+        await userEvent.click(pageNo5);
+        expectPageNavigationButtonAvailability("lastPage");
+      }
+    );
+
+    await step("Select page one by one", async () => {
+      await waitForStoryToBeReady();
+      await userEvent.click(pageSizeButton);
+      const itemPerPage50 = canvas.getByRole("option", { name: "50" });
+      await userEvent.click(itemPerPage50);
+      await waitFor(() => expect(pageSizeButton).toHaveTextContent("50"));
+      await waitFor(() => expect(pageNoButton).toHaveTextContent("1"));
+      expectPageNavigationButtonAvailability("firstPage");
+      await userEvent.click(nextPageButton);
+      expectPageNavigationButtonAvailability("oneOfMiddlePages");
+      await userEvent.click(nextPageButton);
+      expectPageNavigationButtonAvailability("oneOfMiddlePages");
+      await userEvent.click(nextPageButton);
+      expectPageNavigationButtonAvailability("oneOfMiddlePages");
+      await userEvent.click(nextPageButton);
+      expectPageNavigationButtonAvailability("lastPage");
+    });
+
+    await step("Select last page using select component (using search option)", async () => {
+      await waitForStoryToBeReady();
+      await selectItemsPerPage("10");
+
+      await userEvent.click(pageNoButton);
+      await waitFor(() =>
+        expect(getByRole(pageNoButton.parentElement!, "textbox")).toBeInTheDocument()
+      );
+      await userEvent.tab();
+      await waitFor(() => expect(canvas.getByRole("option", { name: "25" })).toBeInTheDocument());
+      await userEvent.keyboard("25");
+      const page25 = canvas.getByRole("option", { name: "25" });
+      await userEvent.click(page25);
+
+      await waitFor(() => expect(pageNoButton).toHaveTextContent("25"));
+      expect(
+        canvas.queryByText(args.translate.currentPage.replace("%1", "25"))
+      ).toBeInTheDocument();
+      expectPageNavigationButtonAvailability("lastPage");
+    });
+  });
+};
+
 Pagination.args = {
   currentPage: 1,
-  pageSize: 10,
-  totalElements: 1000,
+  pageSize: "10",
+  totalElements: 250,
   translate: {
     totalItems: "items in total",
     itemsPerPage: "Items per page",


### PR DESCRIPTION
Fixed pagination `first` button to show 1 page, not 0 page.
Allowed click on `first` & `last` actions when user sees `seconds` and `second to last` page.
Fixed documentation + added docs about `onPageChange` and `onpageSizeChange` callbacks