### PR TITLE
AE-627 | Form Header generic component added

### DIFF
--- a/src/components/Form/FormHeader/FormHeader.module.scss
+++ b/src/components/Form/FormHeader/FormHeader.module.scss
@@ -1,0 +1,25 @@
+$header-height: 13.25rem;
+
+.header {
+  background-color: var(--color-blue-grey25);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem;
+  z-index: 1;
+}
+
+.header-text {
+  margin: 0;
+  font-weight: 700;
+  color: var(--color-primary500);
+  line-height: 2.25rem;
+}
+
+.buttons-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  flex-shrink: 0;
+  gap: 1rem;
+}

--- a/src/components/Form/FormHeader/FormHeader.module.scss
+++ b/src/components/Form/FormHeader/FormHeader.module.scss
@@ -1,5 +1,3 @@
-$header-height: 13.25rem;
-
 .header {
   background-color: var(--color-blue-grey25);
   display: flex;

--- a/src/components/Form/FormHeader/FormHeader.test.tsx
+++ b/src/components/Form/FormHeader/FormHeader.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 OneWelcome B.V.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import React from "react";
+import { FormHeader, Props } from "./FormHeader";
+import { render } from "@testing-library/react";
+import { Button } from "../../Button/Button";
+
+const defaultParams: Props = {
+  children: <p data-testid="formHeaderChildren">Form Header sample description</p>,
+  title: "Form Header sample Title",
+  buttons: [
+    <Button id="cancelButton" key="1" data-testid="button1">
+      Cancel Button
+    </Button>,
+    <Button id="saveButton" key="2" data-testid="button2">
+      Save Button
+    </Button>
+  ]
+};
+
+const createFormHeader = (params?: (defaultParams: Props) => Props) => {
+  let parameters: Props = defaultParams;
+  if (params) {
+    parameters = params(defaultParams);
+  }
+ 
+  const queries = render(<FormHeader {...parameters} data-testid="formHeaderTestId"></FormHeader>);
+  const formHeader = queries.getByTestId("formHeaderTestId");
+  
+  return {
+    ...queries,
+    formHeader,
+  };
+};
+
+describe("FormHeader should render", () => {
+  it("renders without crashing", () => {
+    const { formHeader } = createFormHeader();
+    expect(formHeader).toBeDefined();
+  });
+
+  it("FormHeader has the correct values and attributes", () => {
+    const { getByTestId, getByText } = createFormHeader(defaultParams => ({
+      ...defaultParams,
+      buttons: [
+        <Button id="cancelButton" key="1" data-testid="button1">
+          Cancel Button
+        </Button>,
+        <Button id="saveButton" key="2" data-testid="button2">
+          Save Button
+        </Button>
+      ]
+    }));
+
+    expect(getByTestId("formHeaderChildren")).toHaveTextContent("Form Header sample description");
+    expect(getByText(defaultParams.title)).toBeInTheDocument();
+
+    const button1 = getByTestId("button1");
+
+    expect(button1).toHaveAttribute("id", "cancelButton");
+    expect(button1).toHaveTextContent("Cancel Button");
+
+    const button2 = getByTestId("button2");
+
+    expect(button2).toHaveAttribute("id", "saveButton");
+    expect(button2).toHaveTextContent("Save Button");
+  });
+
+  it("FormHeader has the correct classes", () => {
+    const { formHeader } = createFormHeader(defaultParams => ({
+      ...defaultParams,
+      className: "form-header-custom-class"
+    }));
+
+    expect(formHeader).toHaveClass("form-header-custom-class");
+  });
+
+});

--- a/src/components/Form/FormHeader/FormHeader.test.tsx
+++ b/src/components/Form/FormHeader/FormHeader.test.tsx
@@ -37,13 +37,13 @@ const createFormHeader = (params?: (defaultParams: Props) => Props) => {
   if (params) {
     parameters = params(defaultParams);
   }
- 
+
   const queries = render(<FormHeader {...parameters} data-testid="formHeaderTestId"></FormHeader>);
   const formHeader = queries.getByTestId("formHeaderTestId");
-  
+
   return {
     ...queries,
-    formHeader,
+    formHeader
   };
 };
 
@@ -78,5 +78,4 @@ describe("<FormHeader />", () => {
 
     expect(formHeader).toHaveClass("form-header-custom-class");
   });
-
 });

--- a/src/components/Form/FormHeader/FormHeader.test.tsx
+++ b/src/components/Form/FormHeader/FormHeader.test.tsx
@@ -47,24 +47,14 @@ const createFormHeader = (params?: (defaultParams: Props) => Props) => {
   };
 };
 
-describe("FormHeader should render", () => {
-  it("renders without crashing", () => {
+describe("<FormHeader />", () => {
+  it("should render without crashing", () => {
     const { formHeader } = createFormHeader();
     expect(formHeader).toBeDefined();
   });
 
-  it("FormHeader has the correct values and attributes", () => {
-    const { getByTestId, getByText } = createFormHeader(defaultParams => ({
-      ...defaultParams,
-      buttons: [
-        <Button id="cancelButton" key="1" data-testid="button1">
-          Cancel Button
-        </Button>,
-        <Button id="saveButton" key="2" data-testid="button2">
-          Save Button
-        </Button>
-      ]
-    }));
+  it("should have the correct values and attributes", () => {
+    const { getByTestId, getByText } = createFormHeader();
 
     expect(getByTestId("formHeaderChildren")).toHaveTextContent("Form Header sample description");
     expect(getByText(defaultParams.title)).toBeInTheDocument();
@@ -80,7 +70,7 @@ describe("FormHeader should render", () => {
     expect(button2).toHaveTextContent("Save Button");
   });
 
-  it("FormHeader has the correct classes", () => {
+  it("should have the correct classes", () => {
     const { formHeader } = createFormHeader(defaultParams => ({
       ...defaultParams,
       className: "form-header-custom-class"

--- a/src/components/Form/FormHeader/FormHeader.tsx
+++ b/src/components/Form/FormHeader/FormHeader.tsx
@@ -14,11 +14,11 @@
  *    limitations under the License.
  */
 
-import React, { ComponentPropsWithRef, ReactElement } from "react";
+import React, { HTMLAttributes, ReactElement } from "react";
 import classes from "./FormHeader.module.scss";
 import { Button, ButtonProps, Typography } from "../../..";
 
-export interface Props extends ComponentPropsWithRef<"div"> {
+export interface Props extends HTMLAttributes<HTMLDivElement> {
   title: string;
   buttons: ReactElement<ButtonProps, typeof Button> | ReactElement<ButtonProps, typeof Button>[];
 }
@@ -34,9 +34,7 @@ export const FormHeader = ({ title, children, buttons, ...rest }: Props) => {
           {children}
         </Typography>
       </div>
-      <div className={classes["buttons-wrapper"]}>
-        {buttons}
-      </div>
+      <div className={classes["buttons-wrapper"]}>{buttons}</div>
     </div>
   );
 };

--- a/src/components/Form/FormHeader/FormHeader.tsx
+++ b/src/components/Form/FormHeader/FormHeader.tsx
@@ -14,18 +14,18 @@
  *    limitations under the License.
  */
 
-import React from "react";
+import React, { ComponentPropsWithRef, ReactElement } from "react";
 import classes from "./FormHeader.module.scss";
-import { Button, ButtonProps, Typography, generateID } from "../../..";
+import { Button, ButtonProps, Typography } from "../../..";
 
-export interface Props extends React.HTMLAttributes<"Div"> {
+export interface Props extends ComponentPropsWithRef<"div"> {
   title: string;
   formButtonList: Array<ButtonProps>;
 }
 
-export const FormHeader = ({ title, children, formButtonList }: Props) => {
+export const FormHeader = ({ title, children, formButtonList, ...rest }: Props) => {
   return (
-    <div className={classes["header"]}>
+    <div className={`${classes["header"]} ${rest.className}`} {...rest}>
       <div>
         <Typography className={classes["header-text"]} variant={"h3"}>
           {title}
@@ -35,16 +35,11 @@ export const FormHeader = ({ title, children, formButtonList }: Props) => {
         </Typography>
       </div>
       <div className={classes["buttons-wrapper"]}>
-        {formButtonList?.map(btn => {
+        {formButtonList?.map((btn, index) => {
           return (
             <Button
               {...btn}
-              key={generateID()}
-              onClick={btn.onClick}
-              variant={btn.variant}
-              startIcon={btn.startIcon}
-              endIcon={btn.endIcon}
-              form={btn.form}
+              key={index}
             >
               {btn.title}
             </Button>

--- a/src/components/Form/FormHeader/FormHeader.tsx
+++ b/src/components/Form/FormHeader/FormHeader.tsx
@@ -20,10 +20,10 @@ import { Button, ButtonProps, Typography } from "../../..";
 
 export interface Props extends ComponentPropsWithRef<"div"> {
   title: string;
-  formButtonList: ReactElement<ButtonProps, typeof Button>[];
+  buttons: ReactElement<ButtonProps, typeof Button> | ReactElement<ButtonProps, typeof Button>[];
 }
 
-export const FormHeader = ({ title, children, formButtonList, ...rest }: Props) => {
+export const FormHeader = ({ title, children, buttons, ...rest }: Props) => {
   return (
     <div className={`${classes["header"]} ${rest.className}`} {...rest}>
       <div>
@@ -35,7 +35,7 @@ export const FormHeader = ({ title, children, formButtonList, ...rest }: Props) 
         </Typography>
       </div>
       <div className={classes["buttons-wrapper"]}>
-        {formButtonList}
+        {buttons}
       </div>
     </div>
   );

--- a/src/components/Form/FormHeader/FormHeader.tsx
+++ b/src/components/Form/FormHeader/FormHeader.tsx
@@ -20,7 +20,7 @@ import { Button, ButtonProps, Typography } from "../../..";
 
 export interface Props extends ComponentPropsWithRef<"div"> {
   title: string;
-  formButtonList: Array<ButtonProps>;
+  formButtonList: ReactElement<ButtonProps, typeof Button>[];
 }
 
 export const FormHeader = ({ title, children, formButtonList, ...rest }: Props) => {
@@ -35,16 +35,7 @@ export const FormHeader = ({ title, children, formButtonList, ...rest }: Props) 
         </Typography>
       </div>
       <div className={classes["buttons-wrapper"]}>
-        {formButtonList?.map((btn, index) => {
-          return (
-            <Button
-              {...btn}
-              key={index}
-            >
-              {btn.title}
-            </Button>
-          );
-        })}
+        {formButtonList}
       </div>
     </div>
   );

--- a/src/components/Form/FormHeader/FormHeader.tsx
+++ b/src/components/Form/FormHeader/FormHeader.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 OneWelcome B.V.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import React from "react";
+import classes from "./FormHeader.module.scss";
+import { Button, ButtonProps, Typography, generateID } from "../../..";
+
+export interface Props extends React.HTMLAttributes<"Div"> {
+  title: string;
+  formButtonList: Array<ButtonProps>;
+}
+
+export const FormHeader = ({ title, children, formButtonList }: Props) => {
+  return (
+    <div className={classes["header"]}>
+      <div>
+        <Typography className={classes["header-text"]} variant={"h3"}>
+          {title}
+        </Typography>
+        <Typography variant={"body"} spacing={{ margin: 0 }}>
+          {children}
+        </Typography>
+      </div>
+      <div className={classes["buttons-wrapper"]}>
+        {formButtonList?.map(btn => {
+          return (
+            <Button
+              {...btn}
+              key={generateID()}
+              onClick={btn.onClick}
+              variant={btn.variant}
+              startIcon={btn.startIcon}
+              endIcon={btn.endIcon}
+              form={btn.form}
+            >
+              {btn.title}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Form/FormHeader/FormHeader.tsx
+++ b/src/components/Form/FormHeader/FormHeader.tsx
@@ -15,8 +15,10 @@
  */
 
 import React, { HTMLAttributes, ReactElement } from "react";
+import { Button, Props as ButtonProps } from "../../Button/Button";
+import { Typography } from "../../Typography/Typography";
+
 import classes from "./FormHeader.module.scss";
-import { Button, ButtonProps, Typography } from "../../..";
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
   title: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,8 @@ export { FileUpload } from "./components/Form/FileUpload/FileUpload";
 export type { Props as FileUploadProps } from "./components/Form/FileUpload/FileUpload";
 export { MultiSelectWrapper } from "./components/Form/Wrapper/MultiSelectWrapper/MultiSelectWrapper";
 export type { Props as MultiSelectWrapperProps } from "./components/Form/Wrapper/MultiSelectWrapper/MultiSelectWrapper";
+export { FormHeader } from "./components/Form/FormHeader/FormHeader";
+export type { Props as FormHeaderProps } from "./components/Form/FormHeader/FormHeader";
 
 /** Wizard */
 export { Wizard } from "./components/Wizard/Wizard";

--- a/stories/Form/FormHeader/FormHeader.mdx
+++ b/stories/Form/FormHeader/FormHeader.mdx
@@ -1,0 +1,52 @@
+import { Canvas, Story, Title, Subtitle, ArgTypes, PRIMARY_STORY } from "@storybook/blocks";
+import * as FormHeaderStories from "./FormHeader.stories.tsx";
+
+<Title />
+<Subtitle />
+
+The `FormHeader` component will be used as a wrapper component for header of a form. Its root element is the default HTML `div` tag and thus also accepts all of its HTML attributes. You should use this component whenever you want to create a `FormHeader`.
+
+# Examples
+
+The `FormHeader` component is a wrapper componet for creating the header of a form. See the code snippet below that showcases how you can use it.
+
+```jsx
+
+const formButtonList: Array<ButtonProps> = [
+    {
+      title: "Cancel",
+      onClick: () => {
+        alert('Cancel button is clicked.')
+      },
+      variant:"text"
+    },
+    {
+      title: "Save Draft",
+      disabled: true,
+      startIcon: getReactNode(Icons.SaveOutline)
+    },
+    {
+      title: "Submit",
+      type: "submit",
+      startIcon: getReactNode(Icons.ReplyOutline),
+      form: formId,
+      onClick: () => {
+        alert("Submit button clicked.")
+      }
+    }
+  ];
+
+ <FormHeader
+    title= {"Form Header Text"}
+    formButtonList={formButtonList}>
+        <p>Form <i>Description</i></p>
+ </FormHeader>
+```
+
+<Canvas>
+  <Story of={FormHeaderStories.FormHeaderComponent1} />
+</Canvas>
+
+# Props
+
+<ArgTypes story={PRIMARY_STORY} />{" "}

--- a/stories/Form/FormHeader/FormHeader.mdx
+++ b/stories/Form/FormHeader/FormHeader.mdx
@@ -12,29 +12,17 @@ The `FormHeader` component is a wrapper componet for creating the header of a fo
 
 ```jsx
 
-const formButtonList: Array<ButtonProps> = [
-    {
-      title: "Cancel",
-      onClick: () => {
-        alert('Cancel button is clicked.')
-      },
-      variant:"text"
-    },
-    {
-      title: "Save Draft",
-      disabled: true,
-      startIcon: getReactNode(Icons.SaveOutline)
-    },
-    {
-      title: "Submit",
-      type: "submit",
-      startIcon: getReactNode(Icons.ReplyOutline),
-      form: formId,
-      onClick: () => {
-        alert("Submit button clicked.")
-      }
-    }
-  ];
+const formButtonList: ReactElement<ButtonProps, typeof Button>[] = [
+  <Button key="1" onClick={() => alert("Cancel button clicked.")} variant="text">
+    Cancel
+  </Button>,
+  <Button key="2" disabled>
+    Save Draft
+  </Button>,
+  <Button key="3" onClick={() => alert("Submit button clicked.")} startIcon={getReactNode(Icons.Circle)}>
+    Submit
+  </Button>
+];
 
  <FormHeader
     title= {"Form Header Text"}

--- a/stories/Form/FormHeader/FormHeader.mdx
+++ b/stories/Form/FormHeader/FormHeader.mdx
@@ -16,18 +16,18 @@ const buttons: ReactElement<ButtonProps, typeof Button>[] = [
   <Button key="1" onClick={() => alert("Cancel button clicked.")} variant="text">
     Cancel
   </Button>,
-  <Button key="2" disabled>
+  <Button key="2" disabled startIcon={<Icon icon={Icons.SaveOutline} />}>
     Save Draft
   </Button>,
-  <Button key="3" onClick={() => alert("Submit button clicked.")} startIcon={getReactNode(Icons.Circle)}>
+  <Button key="3" onClick={() => alert("Submit button clicked.")} startIcon={<Icon icon={Icons.ReplyOutline} />}>
     Submit
   </Button>
 ];
 
  <FormHeader
-    title= {"Form Header Text"}
-    buttons={buttons}>
-        <p>Form <i>Description</i></p>
+  title= {"Form Header Text"}
+  buttons={buttons}>
+    Form Description
  </FormHeader>
 ```
 

--- a/stories/Form/FormHeader/FormHeader.mdx
+++ b/stories/Form/FormHeader/FormHeader.mdx
@@ -12,7 +12,7 @@ The `FormHeader` component is a wrapper componet for creating the header of a fo
 
 ```jsx
 
-const formButtonList: ReactElement<ButtonProps, typeof Button>[] = [
+const buttons: ReactElement<ButtonProps, typeof Button>[] = [
   <Button key="1" onClick={() => alert("Cancel button clicked.")} variant="text">
     Cancel
   </Button>,
@@ -26,7 +26,7 @@ const formButtonList: ReactElement<ButtonProps, typeof Button>[] = [
 
  <FormHeader
     title= {"Form Header Text"}
-    formButtonList={formButtonList}>
+    buttons={buttons}>
         <p>Form <i>Description</i></p>
  </FormHeader>
 ```

--- a/stories/Form/FormHeader/FormHeader.stories.tsx
+++ b/stories/Form/FormHeader/FormHeader.stories.tsx
@@ -5,21 +5,21 @@ import {
   Props
 } from "../../../src/components/Form/FormHeader/FormHeader";
 import FormHeaderDocumentation from "./FormHeader.mdx";
-import React, { ReactElement } from "react";
+import React, { Fragment, ReactElement } from "react";
 import { Button, ButtonProps, Icon, Icons } from "../../../src";
-
-const getReactNode = (icons: Icons) => {
-  return (<Icon icon={icons} />) as React.ReactNode;
-};
 
 const formButtonList: ReactElement<ButtonProps, typeof Button>[] = [
   <Button key="1" onClick={() => alert("Cancel button clicked.")} variant="text">
     Cancel
   </Button>,
-  <Button key="2" disabled>
+  <Button key="2" disabled startIcon={<Icon icon={Icons.SaveOutline} />}>
     Save Draft
   </Button>,
-  <Button key="3" onClick={() => alert("Submit button clicked.")} startIcon={getReactNode(Icons.Circle)}>
+  <Button
+    key="3"
+    onClick={() => alert("Submit button clicked.")}
+    startIcon={<Icon icon={Icons.ReplyOutline} />}
+  >
     Submit
   </Button>
 ];
@@ -34,38 +34,24 @@ const meta: Meta = {
   },
   args: {
     title: "Form Header Text",
-    children: (
-      <p>
-        Form <i>Description</i>
-      </p>
-    ),
-    formButtonList: formButtonList
+    children: "Form Description",
+    buttons: formButtonList
   }
 };
 
 export default meta;
 
-const defaultArgs: Props = {
-  title: "Form Header Text",
-  children: (
-    <p>
-      Form <i>Description</i>
-    </p>
-  ),
-  buttons: []
-};
-
 const Template: Story<Props> = args => <FormHeader {...args} />;
-export const FormHeaderComponent1 = Template.bind({});
 
-FormHeaderComponent1.args = {
-  ...defaultArgs,
-  buttons:formButtonList
-};
+export const FormHeaderComponent1 = Template.bind({});
 
 export const FormHeaderComponent2 = Template.bind({});
 
 FormHeaderComponent2.args = {
-  ...defaultArgs,
+  children: (
+    <Fragment>
+      Form <i>Description</i>
+    </Fragment>
+  ),
   buttons: formButtonList.slice(0, 2)
 };

--- a/stories/Form/FormHeader/FormHeader.stories.tsx
+++ b/stories/Form/FormHeader/FormHeader.stories.tsx
@@ -5,33 +5,23 @@ import {
   Props
 } from "../../../src/components/Form/FormHeader/FormHeader";
 import FormHeaderDocumentation from "./FormHeader.mdx";
-import React from "react";
-import { ButtonProps, Icon, Icons } from "../../../src";
+import React, { ReactElement } from "react";
+import { Button, ButtonProps, Icon, Icons } from "../../../src";
 
 const getReactNode = (icons: Icons) => {
   return (<Icon icon={icons} />) as React.ReactNode;
 };
 
-const formButtonList: Array<ButtonProps> = [
-  {
-    title: "Cancel",
-    onClick: () => {
-      alert("Cancel button is clicked.");
-    },
-    variant: "text"
-  },
-  {
-    title: "Save Draft",
-    disabled: true
-  },
-  {
-    title: "Submit",
-    type: "submit",
-    startIcon: getReactNode(Icons.ReplyOutline),
-    onClick: () => {
-      alert("Submit button clicked.");
-    }
-  }
+const formButtonList: ReactElement<ButtonProps, typeof Button>[] = [
+  <Button key="1" onClick={() => alert("Cancel button clicked.")} variant="text">
+    Cancel
+  </Button>,
+  <Button key="2" disabled>
+    Save Draft
+  </Button>,
+  <Button key="3" onClick={() => alert("Submit button clicked.")} startIcon={getReactNode(Icons.Circle)}>
+    Submit
+  </Button>
 ];
 
 const meta: Meta = {
@@ -62,14 +52,15 @@ const defaultArgs: Props = {
       Form <i>Description</i>
     </p>
   ),
-  formButtonList: formButtonList
+  formButtonList: []
 };
 
 const Template: Story<Props> = args => <FormHeader {...args} />;
 export const FormHeaderComponent1 = Template.bind({});
 
 FormHeaderComponent1.args = {
-  ...defaultArgs
+  ...defaultArgs,
+  formButtonList:formButtonList
 };
 
 export const FormHeaderComponent2 = Template.bind({});

--- a/stories/Form/FormHeader/FormHeader.stories.tsx
+++ b/stories/Form/FormHeader/FormHeader.stories.tsx
@@ -1,0 +1,80 @@
+import { Meta, Story } from "@storybook/react";
+import {
+  FormHeader,
+  FormHeader as FormHeaderComponent,
+  Props
+} from "../../../src/components/Form/FormHeader/FormHeader";
+import FormHeaderDocumentation from "./FormHeader.mdx";
+import React from "react";
+import { ButtonProps, Icon, Icons } from "../../../src";
+
+const getReactNode = (icons: Icons) => {
+  return (<Icon icon={icons} />) as React.ReactNode;
+};
+
+const formButtonList: Array<ButtonProps> = [
+  {
+    title: "Cancel",
+    onClick: () => {
+      alert("Cancel button is clicked.");
+    },
+    variant: "text"
+  },
+  {
+    title: "Save Draft",
+    disabled: true
+  },
+  {
+    title: "Submit",
+    type: "submit",
+    startIcon: getReactNode(Icons.ReplyOutline),
+    onClick: () => {
+      alert("Submit button clicked.");
+    }
+  }
+];
+
+const meta: Meta = {
+  title: "Components/layout/FormHeader",
+  component: FormHeaderComponent,
+  parameters: {
+    docs: {
+      page: FormHeaderDocumentation
+    }
+  },
+  args: {
+    title: "Form Header Text",
+    children: (
+      <p>
+        Form <i>Description</i>
+      </p>
+    ),
+    formButtonList: formButtonList
+  }
+};
+
+export default meta;
+
+const defaultArgs: Props = {
+  title: "Form Header Text",
+  children: (
+    <p>
+      Form <i>Description</i>
+    </p>
+  ),
+  formButtonList: formButtonList
+};
+
+const Template: Story<Props> = args => <FormHeader {...args} />;
+export const FormHeaderComponent1 = Template.bind({});
+
+FormHeaderComponent1.args = {
+  ...defaultArgs
+};
+
+export const FormHeaderComponent2 = Template.bind({});
+
+FormHeaderComponent2.args = {
+  ...defaultArgs,
+  formButtonList: formButtonList.slice(0, 2)
+};

--- a/stories/Form/FormHeader/FormHeader.stories.tsx
+++ b/stories/Form/FormHeader/FormHeader.stories.tsx
@@ -52,7 +52,7 @@ const defaultArgs: Props = {
       Form <i>Description</i>
     </p>
   ),
-  formButtonList: []
+  buttons: []
 };
 
 const Template: Story<Props> = args => <FormHeader {...args} />;
@@ -60,12 +60,12 @@ export const FormHeaderComponent1 = Template.bind({});
 
 FormHeaderComponent1.args = {
   ...defaultArgs,
-  formButtonList:formButtonList
+  buttons:formButtonList
 };
 
 export const FormHeaderComponent2 = Template.bind({});
 
 FormHeaderComponent2.args = {
   ...defaultArgs,
-  formButtonList: formButtonList.slice(0, 2)
+  buttons: formButtonList.slice(0, 2)
 };


### PR DESCRIPTION
- Form Header Component Added.
- Stories doc updated.
- export the FormHeader component
- CT is missing.

![image](https://github.com/onewelcome/react-lib-components/assets/126144731/adc77d86-3298-4c76-b41c-5c1040b2e818)
![image](https://github.com/onewelcome/react-lib-components/assets/126144731/9dad2ae0-5759-42b7-9654-e60d68e31c72)
![image](https://github.com/onewelcome/react-lib-components/assets/126144731/c4b7b7dd-9de6-44ce-aa4a-3abbe13a14dd)
