### PR TITLE
UCL-592 Add hash for classnames

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,8 +19,18 @@ import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import postcss from "rollup-plugin-postcss";
 import postcssUrl from "postcss-url";
-import terser from '@rollup/plugin-terser';
+import terser from "@rollup/plugin-terser";
 import path from "path";
+
+const generateRandomSalt = (length: number = 5): string => {
+  const possibleChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let salt = "";
+  for (let i = 0; i < length; i++) {
+    salt += possibleChars.charAt(Math.floor(Math.random() * possibleChars.length));
+  }
+  return salt;
+};
+const randomSalt = generateRandomSalt();
 
 const packageJson = require("./package.json");
 
@@ -29,7 +39,9 @@ const baseConfig = {
     resolve(),
     commonjs(),
     postcss({
-      modules: true,
+      modules: {
+        generateScopedName: (name, filename, css) => `_${name}_${randomSalt}`
+      },
       inject: true,
       minimize: true,
       sourceMap: true,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,6 +22,8 @@ import postcssUrl from "postcss-url";
 import terser from "@rollup/plugin-terser";
 import path from "path";
 
+const packageJson = require("./package.json");
+
 const generateRandomSalt = (length = 5) => {
   const possibleChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   let salt = "";
@@ -32,15 +34,16 @@ const generateRandomSalt = (length = 5) => {
 };
 const randomSalt = generateRandomSalt();
 
-const packageJson = require("./package.json");
-
 const baseConfig = {
   plugins: [
     resolve(),
     commonjs(),
     postcss({
       modules: {
-        generateScopedName: (name, filename, css) => `_${name}_${randomSalt}`
+        generateScopedName: (name, filename) => {
+          const filenameWithoutExt = path.basename(filename).split(".")[0];
+          return `${filenameWithoutExt}_${name}_${randomSalt}`;
+        }
       },
       inject: true,
       minimize: true,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,7 +22,7 @@ import postcssUrl from "postcss-url";
 import terser from "@rollup/plugin-terser";
 import path from "path";
 
-const generateRandomSalt = (length: number = 5): string => {
+const generateRandomSalt = (length = 5) => {
   const possibleChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   let salt = "";
   for (let i = 0; i < length; i++) {


### PR DESCRIPTION
Every build of component library creates new hash and adds it to classname. This fixes issue with multiple styles being applied and clashes with styles that differs between versions.