### PR TITLE
UC-98 Issues when uploading file for the second time

### DIFF
--- a/src/components/Form/FileUpload/FileUpload.test.tsx
+++ b/src/components/Form/FileUpload/FileUpload.test.tsx
@@ -325,7 +325,7 @@ describe("upload action", () => {
     expect(errorMessage.innerHTML).toStrictEqual("You can upload only a single file.");
   });
 
-  it("doesn't upload a file two times", async () => {
+  it("should allow upload of the same file again (e.g. after deletion from file items)", async () => {
     const onChange = jest.fn();
     const { component } = createComponent(
       defaultParams => ({
@@ -353,7 +353,7 @@ describe("upload action", () => {
         user.upload(component, file);
       });
     });
-    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
   it("doesn't allows files to be dropped according to the accepted file types", async () => {

--- a/src/components/Form/FileUpload/FileUpload.tsx
+++ b/src/components/Form/FileUpload/FileUpload.tsx
@@ -154,6 +154,7 @@ const FileUploadComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
 
     if (isFileValid) {
       setErrorMsg("");
+      e.target.value = "";
       onChange?.(files);
     }
   };
@@ -295,7 +296,6 @@ const FileUploadComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
                     accept={accept}
                     onChange={onInputChange}
                     spellCheck={false}
-                    value=""
                   />
                 </Button>
               </div>

--- a/src/components/Form/FileUpload/FileUpload.tsx
+++ b/src/components/Form/FileUpload/FileUpload.tsx
@@ -151,10 +151,11 @@ const FileUploadComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
     e.stopPropagation();
     const files = getFileList(e.target.files);
     const isFileValid = files.length && verifyExtensionValidity(files[files.length - 1]);
+
     if (isFileValid) {
       setErrorMsg("");
+      onChange?.(files);
     }
-    isFileValid && onChange?.(files);
   };
 
   const verifyExtensionValidity = (file: FileType) => {
@@ -294,6 +295,7 @@ const FileUploadComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
                     accept={accept}
                     onChange={onInputChange}
                     spellCheck={false}
+                    value=""
                   />
                 </Button>
               </div>

--- a/src/hooks/useUploadFile.tsx
+++ b/src/hooks/useUploadFile.tsx
@@ -106,7 +106,7 @@ export const useUploadFile = (
       const updatedList = getUpdatedList(fileName, fileStatus, undefined, error);
       setUpdatedFiles(updatedList);
       const response = { fileList: updatedList, status, responseJson };
-      setUploadingFiles(prevState => prevState.filter(selected => selected.name === fileName));
+      setUploadingFiles(prevState => prevState.filter(selected => selected.name !== fileName));
       onComplete?.(response);
     }
   };


### PR DESCRIPTION
Fixed by resetting input value after selecting file/s.

Note that the fix is on UCL, so to have it in UC, theme-management-ui have to use a new release.